### PR TITLE
publish merged into release before artifacts

### DIFF
--- a/.github/workflows/build-for-snapshot-tag.yml
+++ b/.github/workflows/build-for-snapshot-tag.yml
@@ -128,15 +128,15 @@ jobs:
           mv artifacts/merged/ghidra.zip artifacts/merged/$basename.zip
           echo "output-name=$basename.zip" >> $GITHUB_OUTPUT
 
+      - name: update-release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: artifacts/merged/${{ steps.merge-artifacts.outputs.output-name }}
+
       - name: upload merged artifact
         uses: actions/upload-artifact@v3
         with:
           name: merged
           path: artifacts/merged
           retention-days: 1
-
-      - name: update-release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: artifacts/merged/${{ steps.merge-artifacts.outputs.output-name }}


### PR DESCRIPTION
Release: correct place
Actions Artifact: debugging/data passing place

So publishing to release should be before uploading to artifacts.